### PR TITLE
Fix Travis OSX tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
   include:
     - os: osx
       node_js: "6"
-      env: TEST_TYPE="test-ci -- -- --maxWorkers 1"
+      env: TEST_TYPE="test-ci -- -- --maxWorkers 3"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/bootstrap-env-ubuntu.sh; fi


### PR DESCRIPTION
**Summary**
Travis tests on OSX seems to failed **A LOT**
 because of this :

```
<--- Last few GCs --->

 1207511 ms: Mark-sweep 1362.1 (1435.5) -> 1362.1 (1435.5) MB, 2697.2 / 0.0 ms [allocation failure] [GC in old space requested].
 1210266 ms: Mark-sweep 1362.1 (1435.5) -> 1362.1 (1435.5) MB, 2754.3 / 0.1 ms [allocation failure] [GC in old space requested].
 1213441 ms: Mark-sweep 1362.1 (1435.5) -> 1385.1 (1411.5) MB, 3175.0 / 0.1 ms [last resort gc].
 1217347 ms: Mark-sweep 1385.1 (1411.5) -> 1408.1 (1411.5) MB, 3905.5 / 0.1 ms [last resort gc].

<--- JS stacktrace --->
==== JS stack trace =========================================
Security context: 0x5f7e3bcfb39 <JS Object>
    2: _tickCallback [internal/process/next_tick.js:~93] [pc=0x109f829ab8e3] (this=0x1c51837a7319 <a process with map 0x2c6ee9c11a91>)

==== Details ================================================
[2]: _tickCallback [internal/process/next_tick.js:~93] [pc=0x109f829ab8e3] (this=0x1c51837a7319 <a process with map 0x2c6ee9c11a91>) {

// optimized frame
--------- s o u r c e   c o d e ---------
fun...
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 2: node::FatalException(v8::Isolate*, v8::Local<v8::Value>, v8::Local<v8::Message>) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 3: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 4: v8::internal::Factory::NewStruct(v8::internal::InstanceType) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 5: v8::internal::Factory::NewTypeFeedbackInfo() [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 6: v8::internal::FullCodeGenerator::MakeCode(v8::internal::CompilationInfo*) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 7: v8::internal::(anonymous namespace)::GenerateBaselineCode(v8::internal::CompilationInfo*) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 8: v8::internal::(anonymous namespace)::GetUnoptimizedCodeCommon(v8::internal::CompilationInfo*) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
 9: v8::internal::Compiler::Compile(v8::internal::Handle<v8::internal::JSFunction>, v8::internal::Compiler::ClearExceptionFlag) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
10: v8::internal::Runtime_CompileLazy(int, v8::internal::Object**, v8::internal::Isolate*) [/Users/travis/.nvm/versions/node/v6.10.3/bin/node]
11: 0x109f7ce092a7
12: 0x109f7ce34338
13: 0x109f829ab8e3
sh: line 1:  6601 Abort trap: 6           npm run test-only -- --maxWorkers 1
error Command failed with exit code 134.
```

I'm not sure of this, but it seems that the test runs out of memory. It seems to work if we use 3 workers.
